### PR TITLE
Fix unvalid gemspec

### DIFF
--- a/gmaps-autocomplete-rails.gemspec
+++ b/gmaps-autocomplete-rails.gemspec
@@ -5,7 +5,7 @@
 
 Gem::Specification.new do |s|
   s.name = "gmaps-autocomplete-rails"
-  s.version = "0.1.2.1"
+  s.version = "0.1.2.2"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Kristian Mandrup"]
@@ -15,41 +15,6 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files = [
     "LICENSE.txt",
     "README.md"
-  ]
-  s.files = [
-    ".document",
-    ".rspec",
-    "CHANGELOG",
-    "Gemfile",
-    "Gemfile.lock",
-    "LICENSE.txt",
-    "README.md",
-    "Rakefile",
-    "VERSION",
-    "gmaps-autocomplete-rails.gemspec",
-    "lib/gmaps-autocomplete-rails.rb",
-    "lib/gmaps-autocomplete/view_helper.rb",
-    "spec/index.html",
-    "spec/init.js",
-    "spec/jquery-ui/images/ui-bg_flat_0_aaaaaa_40x100.png",
-    "spec/jquery-ui/images/ui-bg_glass_55_fbf9ee_1x400.png",
-    "spec/jquery-ui/images/ui-bg_glass_65_ffffff_1x400.png",
-    "spec/jquery-ui/images/ui-bg_glass_75_dadada_1x400.png",
-    "spec/jquery-ui/images/ui-bg_glass_75_e6e6e6_1x400.png",
-    "spec/jquery-ui/images/ui-bg_glass_75_ffffff_1x400.png",
-    "spec/jquery-ui/images/ui-bg_highlight-soft_75_cccccc_1x100.png",
-    "spec/jquery-ui/images/ui-bg_inset-soft_95_fef1ec_1x100.png",
-    "spec/jquery-ui/images/ui-icons_222222_256x240.png",
-    "spec/jquery-ui/images/ui-icons_2e83ff_256x240.png",
-    "spec/jquery-ui/images/ui-icons_454545_256x240.png",
-    "spec/jquery-ui/images/ui-icons_888888_256x240.png",
-    "spec/jquery-ui/images/ui-icons_cd0a0a_256x240.png",
-    "spec/jquery-ui/images/ui-icons_f6cf3b_256x240.png",
-    "spec/jquery-ui/jquery-ui-1.8.16.custom.css",
-    "spec/jquery-ui/jquery.ui.1.8.16.ie.css",
-    "spec/main.css",
-    "spec/spec_helper.rb",
-    "vendor/assets/javascripts/gmaps-autocomplete.js"
   ]
   s.homepage = "http://github.com/kristianmandrup/gmaps-autocomplete-rails"
   s.licenses = ["MIT"]


### PR DESCRIPTION
We can't add the gmaps-auto-complete.js because doesn't add in the files inside the gem.