### PR TITLE
Fixed keyDownHandler and added new feature

### DIFF
--- a/vendor/assets/javascripts/gmaps-auto-complete.coffee
+++ b/vendor/assets/javascripts/gmaps-auto-complete.coffee
@@ -135,14 +135,14 @@ class GmapsCompleter
   # update: should we update the map (center map and position marker)?
   geocodeLookup: ( type, value, update ) ->
     # default value: update = false
-    update ||= false
+    @update ||= false
 
     request = {}
     request[type] = value
 
-    @geocoder.geocode request, performGeocode
+    @geocoder.geocode request, @performGeocode
 
-  performGeocode: (results, status) ->
+  performGeocode: (results, status) =>
     @debug 'performGeocode', status
 
     $(@errorField).html ''
@@ -158,7 +158,7 @@ class GmapsCompleter
       @updateUI results[0].formatted_address, results[0].geometry.location
 
       # Only update the map (position marker and center map) if requested
-      @updateMap(results[0].geometry) if update
+      @updateMap(results[0].geometry) if @update
 
     else
       # Geocoder status ok but no results!?
@@ -239,12 +239,12 @@ class GmapsCompleter
     $(@inputField).autocomplete(autocompleteOpts)
 
     # triggered when user presses a key in the address box
-    $(@inputField).bind 'keydown', @, @keyDownHandler
+    $(@inputField).bind 'keydown', @keyDownHandler
     # autocomplete_init
 
-  keyDownHandler: (event, completer) ->
+  keyDownHandler: (event) =>
     if (event.keyCode == 13)
-      completer.geocodeLookup 'address', $(@inputField).val(), true
+      @geocodeLookup 'address', $(@inputField).val(), true
       # ensures dropdown disappears when enter is pressed
       $(@inputField).autocomplete "disable"
     else

--- a/vendor/assets/javascripts/gmaps-auto-complete.js
+++ b/vendor/assets/javascripts/gmaps-auto-complete.js
@@ -1,4 +1,5 @@
-var GmapsCompleter, GmapsCompleterDefaultAssist;
+var GmapsCompleter, GmapsCompleterDefaultAssist,
+  __bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; };
 
 GmapsCompleter = (function() {
   GmapsCompleter.prototype.geocoder = null;
@@ -36,6 +37,8 @@ GmapsCompleter = (function() {
   GmapsCompleter.prototype.errorField = '#gmaps-error';
 
   function GmapsCompleter(opts) {
+    this.keyDownHandler = __bind(this.keyDownHandler, this);
+    this.performGeocode = __bind(this.performGeocode, this);
     this.init(opts);
   }
 
@@ -128,10 +131,10 @@ GmapsCompleter = (function() {
 
   GmapsCompleter.prototype.geocodeLookup = function(type, value, update) {
     var request;
-    update || (update = false);
+    this.update || (this.update = false);
     request = {};
     request[type] = value;
-    return this.geocoder.geocode(request, performGeocode);
+    return this.geocoder.geocode(request, this.performGeocode);
   };
 
   GmapsCompleter.prototype.performGeocode = function(results, status) {
@@ -148,7 +151,7 @@ GmapsCompleter = (function() {
     this.debug('geocodeSuccess', results);
     if (results[0]) {
       this.updateUI(results[0].formatted_address, results[0].geometry.location);
-      if (update) {
+      if (this.update) {
         return this.updateMap(results[0].geometry);
       }
     } else {
@@ -214,12 +217,12 @@ GmapsCompleter = (function() {
     };
     autocompleteOpts = $.extend(true, defaultAutocompleteOpts, autocompleteOpts);
     $(this.inputField).autocomplete(autocompleteOpts);
-    return $(this.inputField).bind('keydown', this, this.keyDownHandler);
+    return $(this.inputField).bind('keydown', this.keyDownHandler);
   };
 
-  GmapsCompleter.prototype.keyDownHandler = function(event, completer) {
+  GmapsCompleter.prototype.keyDownHandler = function(event) {
     if (event.keyCode === 13) {
-      completer.geocodeLookup('address', $(this.inputField).val(), true);
+      this.geocodeLookup('address', $(this.inputField).val(), true);
       return $(this.inputField).autocomplete("disable");
     } else {
       return $(this.inputField).autocomplete("enable");


### PR DESCRIPTION
Hi,

I added new feature for passing options to JQuery autocomplete in convenient way:

``` coffee
    completer = new GmapsCompleter

    completer.autoCompleteInit
      country: "us"
      autocomplete:
        minLength: 4
        position: 
          my : "center top", 
          at: "center bottom-1"
          collision: "none"
```

This _autocomplete_ object will be merged with default _source_ and _select_ functions and passed to JQuery autocomplete widget.

Also I fixed issues with _this_ in keyDownHandler.
