### PR TITLE
Add option for scrollwheel

### DIFF
--- a/vendor/assets/javascripts/gmaps-auto-complete.coffee
+++ b/vendor/assets/javascripts/gmaps-auto-complete.coffee
@@ -63,6 +63,7 @@ class GmapsCompleter
     @mapType  = google.maps.MapTypeId.ROADMAP
 
     zoomLevel = opts['zoomLevel']
+    scrollwheel = opts['scrollwheel']
 
     @inputField = opts['inputField']
     @errorField = opts['#gmaps-error']
@@ -79,6 +80,7 @@ class GmapsCompleter
 
     mapOptions =
       zoom: zoomLevel
+      scrollwheel: scrollwheel
       center: latlng
       mapTypeId: mapType
 


### PR DESCRIPTION
Previously you had no option to disable the `scrollwheel` on the Map object. This small change adds the ability to set the `scrollwheel` flag.